### PR TITLE
[aques_talk] Fix architecture type for docker

### DIFF
--- a/3rdparty/aques_talk/CMakeLists.txt
+++ b/3rdparty/aques_talk/CMakeLists.txt
@@ -5,7 +5,8 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES x86_64* )
+execute_process(COMMAND dpkg-architecture -qDEB_HOST_GNU_CPU OUTPUT_VARIABLE ARCHITECTURE)
+if("${ARCHITECTURE}" MATCHES x86_64* )
 set(AQTK2_LNX_LIB_DIR "lib64")
 else ()
 set(AQTK2_LNX_LIB_DIR "lib")

--- a/3rdparty/aques_talk/CMakeLists.txt
+++ b/3rdparty/aques_talk/CMakeLists.txt
@@ -5,6 +5,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+# Considering the use of docker in addition to the usual use,
+# we use dpkg-architecture command instead of ${CMAKE_SYSTEM_PROCESSOR} to get the architecture.
+# https://stackoverflow.com/a/58222507
+# http://manpages.ubuntu.com/manpages/bionic/man1/dpkg-architecture.1.html
 execute_process(COMMAND dpkg-architecture -qDEB_HOST_GNU_CPU OUTPUT_VARIABLE ARCHITECTURE)
 if("${ARCHITECTURE}" MATCHES x86_64* )
 set(AQTK2_LNX_LIB_DIR "lib64")


### PR DESCRIPTION
Travis on `i386:kinetic` fails because `${CMAKE_SYSTEM_PROCESSOR}` in CMakeLists.txt returns `x86_64` and libAquesTalk2.so for x86_64 is used.
https://travis-ci.org/github/jsk-ros-pkg/jsk_3rdparty/jobs/745056534
```
Errors << aques_talk:make /home/travis/ros/ws_jsk_3rdparty/logs/aques_talk/build.make.000.log
/usr/bin/ld: skipping incompatible /home/travis/ros/ws_jsk_3rdparty/devel/.private/aques_talk/lib/libAquesTalk2.so when searching for -lAquesTalk2
/usr/bin/ld: cannot find -lAquesTalk2
collect2: error: ld returned 1 exit status
make[2]: *** [/home/travis/ros/ws_jsk_3rdparty/devel/.private/aques_talk/lib/aques_talk/SampleTalk] Error 1
make[1]: *** [CMakeFiles/SampleTalk.dir/all] Error 2
make: *** [all] Error 2
```

To avoid this problem, I use `$ dpkg-architecture -qDEB_HOST_GNU_CPU` command instead.

The output of this command are like below:
```bash
# My Laptop (Ubuntu 18.04, x86_64, not docker)
$ uname -a
Linux naoya-ThinkPad-T460s 5.4.0-53-generic #59~18.04.1-Ubuntu SMP Wed Oct 21 12:14:56 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
$ dpkg-architecture -qDEB_HOST_GNU_CPU
x86_64

# i386:kinetic docker on my laptop
root@791dad51bac1:/home/ws/src/jsk_3rdparty/3rdparty/aques_talk# uname -a
Linux 791dad51bac1 5.4.0-53-generic #59~18.04.1-Ubuntu SMP Wed Oct 21 12:14:56 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
root@791dad51bac1:/home/ws/src/jsk_3rdparty/3rdparty/aques_talk# dpkg-architecture -qDEB_HOST_GNU_CPU
i686;
```