### PR TITLE
Natural Language AIとChaplus APIを組み合わせたデモ

### DIFF
--- a/ros_google_cloud_language/README.md
+++ b/ros_google_cloud_language/README.md
@@ -25,3 +25,42 @@ Do not install `google-cloud-language` manually, it is installed via `catkin_vir
 ```
 roslaunch demo.launch google_cloud_credentials_json:=${HOME}/Downloads/eternal-byte-236613-4bc6962824d1.json
 ```
+
+Additional Topic: Chat with agent
+---------
+
+If you have already run the tutorials, please skip the STEP1 and 2.
+
+1. Install this pacakge
+
+```
+catkin b ros_google_cloud_language
+```
+
+Do not install `google-cloud-language` manually, it is installed via `catkin_virtual_env` to work with rospy.
+
+
+2. Download google credentials file. For JSK users, you can download from [Google Drive](https://drive.google.com/file/d/1VxniytpH9J12ii9jphtBylydY1_k5nXf/view?usp=sharing) link.
+
+
+3. Install Chaplus package
+
+```
+catkin build chaplus_ros
+```
+
+for more detail, please show [chaplus_ros repository](https://github.com/jsk-ros-pkg/jsk_3rdparty/tree/master/chaplus_ros)
+
+4. Download apikey. For JSK users, you can download from [Google Drive](https://drive.google.com/file/d/1wh1_WX3l_qKbUG5wdgeQQBQCu6f9BSWF/view?usp=sharing) link, and please replace `chaplus_ros/apikey.json` with this.
+
+5. Run the sample code
+
+```
+roslaunch ros_google_cloud_language demo_with_chat.launch google_cloud_credentials_json:=${HOME}/Downloads/eternal-byte-236613-4bc6962824d1.json
+```
+
+6. Launch another terminal, and please send what you want to tell the agent, like the following example
+
+```
+rostopic pub -1 /request std_msgs/String "data: 'おはよう'"
+```

--- a/ros_google_cloud_language/samples/client_with_chat.l
+++ b/ros_google_cloud_language/samples/client_with_chat.l
@@ -1,0 +1,53 @@
+#!/usr/bin/env roseus
+
+(ros::roseus-add-msgs "ros_google_cloud_language")
+(ros::load-ros-package "std_msgs")
+(setq *sub-topic* "/response")
+
+
+(defun type-to-string (id)
+  (do-symbols (type "ROS_GOOGLE_CLOUD_LANGUAGE::TEXTENTITY")
+              (if (= (eval type) id)
+                  (return-from type-to-string (symbol-name type))))
+  nil)
+
+;; check if this retuns correct answer with https://cloud.google.com/natural-language
+(defun send-text (text)
+  (let (goal ac ret)
+    (setq goal (instance ros_google_cloud_language::AnalyzeTextActionGoal :init))
+    (send goal :goal :text text)
+    (ros::ros-info "analyze : ~A" (send goal :goal :text))
+    ;;
+    (setq ac (instance ros::simple-action-client :init
+                   "/analyze_text/text" ros_google_cloud_language::AnalyzeTextAction))
+    (send ac :wait-for-server)
+    ;;
+    (send ac :send-goal goal)
+    (when (send ac :wait-for-result :timeout 5)
+      (setq ret (send ac :get-result))
+      (ros::ros-info "sentiment")
+      (ros::ros-info " score : ~A" (send ret :sentiment_score))
+      (ros::ros-info " magnitude : ~A" (send ret :sentiment_magnitude))
+      (ros::ros-info "entiteis")
+      (dolist (entity (send ret :entities))
+        (ros::ros-info " name : ~A" (send entity :name))
+        (ros::ros-info " type : ~A" (type-to-string (send entity :type)))
+        (ros::ros-info " salience : ~A" (send entity :salience))
+        )
+      )))
+
+(defun chat-cb (msg)
+  (setq text (send msg :data))
+  (send-text text)
+  )
+
+(defun chat-demo ()
+  (ros::subscribe *sub-topic* std_msgs::String #'chat-cb)
+  (while (ros::ok)
+    (ros::spin-once)
+    (ros::sleep))
+  )
+
+(ros::roseus "client")
+(chat-demo)
+(exit)

--- a/ros_google_cloud_language/samples/demo_with_chat.launch
+++ b/ros_google_cloud_language/samples/demo_with_chat.launch
@@ -1,0 +1,20 @@
+<launch>
+  <arg name="google_cloud_credentials_json" default="" />
+  <include file="$(find ros_google_cloud_language)/launch/analyze_text.launch" >
+    <arg name="google_cloud_credentials_json" value="$(arg google_cloud_credentials_json)" />
+  </include>
+
+  <!-- start chaplus subscribe /request and publish /response -->
+  <arg name="chatbot_engine" default="Chaplus" />
+  <arg name="use_sample" default="True" />
+  <node pkg="chaplus_ros" type="chaplus_ros.py" name="chaplus_ros"
+        output="screen" >
+    <rosparam subst_value="true">
+      chatbot_engine: $(arg chatbot_engine)
+      use_sample: $(arg use_sample)
+    </rosparam>
+  </node>
+  
+  <node pkg="ros_google_cloud_language" type="client_with_chat.l"
+        name="client" output="screen" />
+</launch>


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/304

Chaplus雑談APIと組み合わせたデモを作ってみました。
rostopicを使ってターミナルの出力と会話をし、その際のエージェントの応答文をNatural Language AIで分析します。
以下、会話の例です。
https://gist.github.com/MiyabiTane/d1d806279d129fde5a25d1ce9018057f

